### PR TITLE
Make reconnect a little safer

### DIFF
--- a/lib/Mojo/SlackRTM.pm
+++ b/lib/Mojo/SlackRTM.pm
@@ -105,8 +105,8 @@ sub connect {
         $self->ws->on(finish => sub {
             my ($ws) = @_;
             $self->log->warn("detect 'finish' event");
-            $self->finish;
-            $self->connect if $self->auto_reconnect;
+            $self->_clear;
+            Mojo::IOLoop->timer(1 => sub { $self->connect }) if $self->auto_reconnect;
         });
     });
 }


### PR DESCRIPTION
At work we were sometimes failing to reconnect. While I couldn't be sure
exactly what was going wrong, I knew I was getting the finish event log
message and then it wouldn't reconnect.

I decided that I would do two things which are reflected in this commit.
I don't call finish on an already finishing websocket; this is
accomplished by changing the SlackRTM->finish call to SlackTRM->_clear.
Then I deferred the reconnect until the next loop tick, since that is
added safety at little cost.

The reconnect issued have since gone away. Therefore I propse these
changes as added safety without much evidence.